### PR TITLE
macOS: Use `llvm-ar` instead of `/usr/bin/ar`

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -108,6 +108,13 @@ add_custom_target(swift-lsp-symlink
 		swift-archive
 )
 
+# Swift toolchain contains "llvm-ar" which we know to be a consistent version of "ar" across platforms.
+# $(dirname $(realpath "$(which swift)"))/llvm-ar
+execute_process(COMMAND which swift OUTPUT_VARIABLE SWIFT_PATH OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND realpath ${SWIFT_PATH} OUTPUT_VARIABLE SWIFT_REAL_PATH OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND dirname ${SWIFT_REAL_PATH} OUTPUT_VARIABLE SWIFT_DIRNAME OUTPUT_STRIP_TRAILING_WHITESPACE)
+set(AR_PATH ${SWIFT_DIRNAME}/llvm-ar)
+
 # Extract Objectfile with app_main() symbol
 # So we can append it to __idf_main and not (just) as archive
 # This is so the linker will correctly resolve dependencies:
@@ -117,7 +124,7 @@ add_custom_command(
 	OUTPUT ${SWIFT_PRODUCT_RELEASE}/_main_swiftcode.o
 	COMMAND
 		# Extract first .o which defines the 'app_main' symbol
-		ar x ${SWIFT_PRODUCT_ARCHIVE} $$\( nm --defined-only -A ${SWIFT_PRODUCT_ARCHIVE} | grep -m 1 ' T app_main' | cut -d: -f2 \) --output ${SWIFT_PRODUCT_RELEASE}
+		${AR_PATH} x ${SWIFT_PRODUCT_ARCHIVE} $$\( nm --defined-only -A ${SWIFT_PRODUCT_ARCHIVE} | grep -m 1 ' T app_main' | cut -d: -f2 \) --output ${SWIFT_PRODUCT_RELEASE}
 		# Rename it to a predicatble file
 		&& \( mv -f -T ${SWIFT_PRODUCT_RELEASE}/$$\( nm --defined-only -A ${SWIFT_PRODUCT_ARCHIVE} | grep -m 1 ' T app_main' | cut -d: -f2 \) ${SWIFT_PRODUCT_RELEASE}/_main_swiftcode.o 2>/dev/null || \(
 			rm -rf ${SWIFT_PRODUCT_RELEASE}/_main_swiftcode.o && mv -f ${SWIFT_PRODUCT_RELEASE}/$$\( nm --defined-only -A ${SWIFT_PRODUCT_ARCHIVE} | grep -m 1 ' T app_main' | cut -d: -f2 \) ${SWIFT_PRODUCT_RELEASE}/_main_swiftcode.o \)


### PR DESCRIPTION
Building failed for me on macOS:

```
[677/907] Generating /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/main/.build/release/_main_swiftcode.oFAILED: /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/main/.build/release/_main_swiftcode.o 
cd /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/build/esp-idf/main && /usr/bin/ar x /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/main/.build/release/libswiftcode.a $( nm --defined-only -A /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/main/.build/release/libswiftcode.a | grep -m 1 ' T app_main' | cut -d: -f2 ) --output /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/main/.build/release && ( mv -f -T /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/main/.build/release/$( nm --defined-only -A /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/main/.build/release/libswiftcode.a | grep -m 1 ' T app_main' | cut -d: -f2 ) /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/main/.build/release/_main_swiftcode.o 2>/dev/null || ( rm -rf /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/main/.build/release/_main_swiftcode.o && mv -f /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/main/.build/release/$( nm --defined-only -A /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/main/.build/release/libswiftcode.a | grep -m 1 ' T app_main' | cut -d: -f2 ) /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/main/.build/release/_main_swiftcode.o ) )
ar: esp_main.swift.o: not found in archive
ar: --output: not found in archive
ar: /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/main/.build/release: not found in archive
```

<details>

<summary>Full `idf.py build` output:</summary>

```
/Users/brianhenry/esp/v5.1-rc2/esp-idf/tools/check_python_dependencies.py:12: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
  import pkg_resources
Executing action: all (aliases: build)
Running cmake in directory /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/build
Executing "cmake -G Ninja -DPYTHON_DEPS_CHECKED=1 -DPYTHON=/Users/brianhenry/.espressif/python_env/idf5.1_py3.11_env/bin/python -DESP_PLATFORM=1 -DCCACHE_ENABLE=0 /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm"...
-- IDF_TARGET is not set, guessed 'esp32c6' from sdkconfig '/Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/sdkconfig'
-- Found Git: /opt/homebrew/bin/git (found version "2.45.2")
-- The C compiler identification is GNU 12.2.0
-- The CXX compiler identification is GNU 12.2.0
-- The ASM compiler identification is GNU
-- Found assembler: /Users/brianhenry/.espressif/tools/riscv32-esp-elf/esp-12.2.0_20230208/riscv32-esp-elf/bin/riscv32-esp-elf-gcc
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Users/brianhenry/.espressif/tools/riscv32-esp-elf/esp-12.2.0_20230208/riscv32-esp-elf/bin/riscv32-esp-elf-gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Users/brianhenry/.espressif/tools/riscv32-esp-elf/esp-12.2.0_20230208/riscv32-esp-elf/bin/riscv32-esp-elf-g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Building ESP-IDF components for target esp32c6
-- Project sdkconfig file /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/sdkconfig
-- Looking for sys/types.h
-- Looking for sys/types.h - found
-- Looking for stdint.h
-- Looking for stdint.h - found
-- Looking for stddef.h
-- Looking for stddef.h - found
-- Check size of time_t
-- Check size of time_t - done
-- Found Python3: /Users/brianhenry/.espressif/python_env/idf5.1_py3.11_env/bin/python (found version "3.11.7") found components: Interpreter
-- Performing Test C_COMPILER_SUPPORTS_WFORMAT_SIGNEDNESS
-- Performing Test C_COMPILER_SUPPORTS_WFORMAT_SIGNEDNESS - Success
-- App "main" version: b33876f-dirty
-- Adding linker script /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/build/esp-idf/esp_system/ld/memory.ld
-- Adding linker script /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_system/ld/esp32c6/sections.ld.in
-- Adding linker script /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_rom/esp32c6/ld/esp32c6.rom.ld
-- Adding linker script /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_rom/esp32c6/ld/esp32c6.rom.api.ld
-- Adding linker script /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_rom/esp32c6/ld/esp32c6.rom.rvfp.ld
-- Adding linker script /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_rom/esp32c6/ld/esp32c6.rom.newlib.ld
-- Adding linker script /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_rom/esp32c6/ld/esp32c6.rom.version.ld
-- Adding linker script /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_rom/esp32c6/ld/esp32c6.rom.phy.ld
-- Adding linker script /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_rom/esp32c6/ld/esp32c6.rom.coexist.ld
-- Adding linker script /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_rom/esp32c6/ld/esp32c6.rom.net80211.ld
-- Adding linker script /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_rom/esp32c6/ld/esp32c6.rom.pp.ld
-- Adding linker script /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_rom/esp32c6/ld/esp32c6.rom.wdt.ld
-- Adding linker script /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_rom/esp32c6/ld/esp32c6.rom.newlib-normal.ld
-- Adding linker script /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_rom/esp32c6/ld/esp32c6.rom.heap.ld
-- Adding linker script /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/soc/esp32c6/ld/esp32c6.peripherals.ld
-- Components: app_trace app_update bootloader bootloader_support bt cmock console cxx driver efuse esp-tls esp_adc esp_app_format esp_coex esp_common esp_eth esp_event esp_gdbstub esp_hid esp_http_client esp_http_server esp_https_ota esp_https_server esp_hw_support esp_lcd esp_local_ctrl esp_mm esp_netif esp_netif_stack esp_partition esp_phy esp_pm esp_psram esp_ringbuf esp_rom esp_system esp_timer esp_wifi espcoredump esptool_py fatfs freertos hal heap http_parser idf_test ieee802154 json log lwip main mbedtls mqtt newlib nvs_flash openthread partition_table protobuf-c protocomm pthread riscv sdmmc soc spi_flash spiffs tcp_transport ulp unity usb vfs wear_levelling wifi_provisioning wpa_supplicant
-- Component paths: /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/app_trace /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/app_update /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/bootloader /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/bootloader_support /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/bt /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/cmock /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/console /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/cxx /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/driver /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/efuse /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp-tls /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_adc /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_app_format /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_coex /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_common /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_eth /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_event /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_gdbstub /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_hid /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_http_client /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_http_server /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_https_ota /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_https_server /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_hw_support /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_lcd /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_local_ctrl /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_mm /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_netif /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_netif_stack /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_partition /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_phy /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_pm /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_psram /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_ringbuf /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_rom /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_system /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_timer /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_wifi /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/espcoredump /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esptool_py /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/fatfs /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/freertos /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/hal /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/heap /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/http_parser /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/idf_test /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/ieee802154 /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/json /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/log /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/lwip /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/main /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/mbedtls /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/mqtt /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/newlib /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/nvs_flash /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/openthread /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/partition_table /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/protobuf-c /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/protocomm /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/pthread /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/riscv /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/sdmmc /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/soc /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/spi_flash /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/spiffs /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/tcp_transport /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/ulp /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/unity /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/usb /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/vfs /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/wear_levelling /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/wifi_provisioning /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/wpa_supplicant
-- Configuring done (3.3s)
-- Generating done (0.4s)
-- Build files have been written to: /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/build
Running ninja in directory /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/build
Executing "ninja all"...
[2/907] cd /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/build/esp-idf/main && ech...Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/main/.build/release/compile_flags.txt
[5/907] Generating ../../partition_table/partition-table.binPartition table binary generated. Contents:
*******************************************************************************
# ESP-IDF Partition Table
# Name, Type, SubType, Offset, Size, Flags
nvs,data,nvs,0x9000,24K,
phy_init,data,phy,0xf000,4K,
factory,app,factory,0x10000,1M,
*******************************************************************************
[181/907] cd /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/build/esp-idf/main && r...wift-esp32-led-blink/swift-embedded-pm/build/config' | tr ';' '\n' | sed -e 's/\(.*\)/-Xcc -I\1/g' )Everything is already up-to-date
Building for production...
[1/2] Archiving libswiftcode.aBuild complete! (0.68s)
[670/907] cd /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/build/esp-idf/main && e...rianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/main/.build/riscv32-none-none-eabi/debug ) )
[677/907] Generating /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/main/.build/release/_main_swiftcode.oFAILED: /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/main/.build/release/_main_swiftcode.o 
cd /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/build/esp-idf/main && /usr/bin/ar x /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/main/.build/release/libswiftcode.a $( nm --defined-only -A /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/main/.build/release/libswiftcode.a | grep -m 1 ' T app_main' | cut -d: -f2 ) --output /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/main/.build/release && ( mv -f -T /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/main/.build/release/$( nm --defined-only -A /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/main/.build/release/libswiftcode.a | grep -m 1 ' T app_main' | cut -d: -f2 ) /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/main/.build/release/_main_swiftcode.o 2>/dev/null || ( rm -rf /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/main/.build/release/_main_swiftcode.o && mv -f /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/main/.build/release/$( nm --defined-only -A /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/main/.build/release/libswiftcode.a | grep -m 1 ' T app_main' | cut -d: -f2 ) /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/main/.build/release/_main_swiftcode.o ) )
ar: esp_main.swift.o: not found in archive
ar: --output: not found in archive
ar: /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/main/.build/release: not found in archive
[679/907] Performing configure step for 'bootloader'-- Found Git: /opt/homebrew/bin/git (found version "2.45.2")
-- The C compiler identification is GNU 12.2.0
-- The CXX compiler identification is GNU 12.2.0
-- The ASM compiler identification is GNU
-- Found assembler: /Users/brianhenry/.espressif/tools/riscv32-esp-elf/esp-12.2.0_20230208/riscv32-esp-elf/bin/riscv32-esp-elf-gcc
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Users/brianhenry/.espressif/tools/riscv32-esp-elf/esp-12.2.0_20230208/riscv32-esp-elf/bin/riscv32-esp-elf-gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Users/brianhenry/.espressif/tools/riscv32-esp-elf/esp-12.2.0_20230208/riscv32-esp-elf/bin/riscv32-esp-elf-g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Building ESP-IDF components for target esp32c6
-- Project sdkconfig file /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/sdkconfig
-- Looking for sys/types.h
-- Looking for sys/types.h - found
-- Looking for stdint.h
-- Looking for stdint.h - found
-- Looking for stddef.h
-- Looking for stddef.h - found
-- Check size of time_t
-- Check size of time_t - done
-- Adding linker script /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/soc/esp32c6/ld/esp32c6.peripherals.ld
-- App "bootloader" version: v5.1-rc2-dirty
-- Adding linker script /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_rom/esp32c6/ld/esp32c6.rom.ld
-- Adding linker script /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_rom/esp32c6/ld/esp32c6.rom.api.ld
-- Adding linker script /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_rom/esp32c6/ld/esp32c6.rom.rvfp.ld
-- Adding linker script /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_rom/esp32c6/ld/esp32c6.rom.newlib.ld
-- Adding linker script /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_rom/esp32c6/ld/esp32c6.rom.phy.ld
-- Adding linker script /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_rom/esp32c6/ld/esp32c6.rom.wdt.ld
-- Adding linker script /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_rom/esp32c6/ld/esp32c6.rom.version.ld
-- Adding linker script /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/bootloader/subproject/main/ld/esp32c6/bootloader.ld
-- Adding linker script /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/bootloader/subproject/main/ld/esp32c6/bootloader.rom.ld
-- Components: bootloader bootloader_support efuse esp_app_format esp_common esp_hw_support esp_rom esp_system esptool_py freertos hal log main micro-ecc newlib partition_table riscv soc spi_flash
-- Component paths: /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/bootloader /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/bootloader_support /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/efuse /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_app_format /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_common /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_hw_support /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_rom /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esp_system /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/esptool_py /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/freertos /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/hal /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/log /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/bootloader/subproject/main /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/bootloader/subproject/components/micro-ecc /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/newlib /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/partition_table /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/riscv /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/soc /Users/brianhenry/esp/v5.1-rc2/esp-idf/components/spi_flash
-- Configuring done (2.5s)
-- Generating done (0.1s)
-- Build files have been written to: /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/build/bootloader
ninja: build stopped: subcommand failed.
ninja failed with exit code 1, output of the command is in the /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/build/log/idf_py_stderr_output_11751 and /Users/brianhenry/Sites/swift-esp32-led-blink/swift-embedded-pm/build/log/idf_py_stdout_output_11751

```

</details>

Changing to use `llvm-ar` at `/Users/brianhenry/Library/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2024-07-25-a.xctoolchain/usr/bin/llvm-ar` worked for me.

I'm determining the path by resolving the `which swift` symlink and assuming it to be in the same `/bin` directory.

I just spent all weekend trying to get code-navigation working in VS Code, then I saw this project. I had tried a Swift Package Manager approach but you are far ahead of me! Some discussion here: https://github.com/swiftlang/vscode-swift/discussions/968 Thanks for all the work. 